### PR TITLE
exit with http error code if != 200

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -126,7 +126,7 @@ logout)
     fi
 
     echo "Pushing $CHART to repo $REPO_URL..."
-    curl -is -u "$AUTH" "$REPO_URL" --upload-file "$CHART_PACKAGE" | indent
+    curl --silent --fail --show-error -u "$AUTH" "$REPO_URL" --upload-file "$CHART_PACKAGE" | indent
     echo "Done"
     ;;
 esac

--- a/push.sh
+++ b/push.sh
@@ -126,7 +126,7 @@ logout)
     fi
 
     echo "Pushing $CHART to repo $REPO_URL..."
-    curl --silent --fail --show-error -u "$AUTH" "$REPO_URL" --upload-file "$CHART_PACKAGE" | indent
+    curl --silent --fail --show-error -u "$AUTH" "$REPO_URL" --upload-file "$CHART_PACKAGE"
     echo "Done"
     ;;
 esac


### PR DESCRIPTION
We need to make the plugin command fails in case of HTTP error

This pull request makes the following changes:
* Redirect curl output in a log file
* Exit with HTTP error code if different than 200